### PR TITLE
Exclude Project/Member Template from Cargo Workspace Members

### DIFF
--- a/2023/Cargo.lock
+++ b/2023/Cargo.lock
@@ -63,16 +63,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
-name = "day"
-version = "0.1.0"
-dependencies = [
- "miette",
- "thiserror",
- "tracing",
- "tracing-subscriber",
-]
-
-[[package]]
 name = "day01"
 version = "0.1.0"
 dependencies = [

--- a/2023/Cargo.toml
+++ b/2023/Cargo.toml
@@ -1,6 +1,7 @@
 [workspace]
 resolver = "2"
 members = ["day*"]
+exclude = ["day-template"]
 
 [workspace.dependencies]
 glam = "0.24"


### PR DESCRIPTION
No point trying to compile/test the [`day-template/`](https://github.com/zanbaldwin/aoc/tree/main/2023/day-template) project in GitHub Actions.